### PR TITLE
fix: harden auth checks and enforce single governance per org

### DIFF
--- a/contracts/protocol/sources/agent.move
+++ b/contracts/protocol/sources/agent.move
@@ -97,6 +97,7 @@ module fractalmind_protocol::agent {
     ) {
         let sender = tx_context::sender(ctx);
         assert!(cert.agent == sender, constants::e_unauthorized());
+        assert!(cert.org_id == organization::org_id(org), constants::e_unauthorized());
         assert!(cert.status == constants::agent_status_active(), constants::e_agent_not_active());
 
         cert.status = constants::agent_status_inactive();

--- a/contracts/protocol/sources/constants.move
+++ b/contracts/protocol/sources/constants.move
@@ -44,6 +44,7 @@ module fractalmind_protocol::constants {
     const E_GOV_VOTING_CLOSED: u64 = 6004;
     const E_GOV_VOTING_NOT_ENDED: u64 = 6005;
     const E_GOV_EMPTY_PROPOSAL_TITLE: u64 = 6006;
+    const E_GOV_ALREADY_EXISTS: u64 = 6007;
 
     // Review errors (7xxx)
     const E_REVIEW_INVALID_TRANSITION: u64 = 7001;
@@ -129,6 +130,7 @@ module fractalmind_protocol::constants {
     public fun e_gov_voting_closed(): u64 { E_GOV_VOTING_CLOSED }
     public fun e_gov_voting_not_ended(): u64 { E_GOV_VOTING_NOT_ENDED }
     public fun e_gov_empty_proposal_title(): u64 { E_GOV_EMPTY_PROPOSAL_TITLE }
+    public fun e_gov_already_exists(): u64 { E_GOV_ALREADY_EXISTS }
     public fun e_review_invalid_transition(): u64 { E_REVIEW_INVALID_TRANSITION }
     public fun e_review_invalid_decision(): u64 { E_REVIEW_INVALID_DECISION }
     public fun e_review_already_reviewed(): u64 { E_REVIEW_ALREADY_REVIEWED }

--- a/contracts/protocol/sources/entry.move
+++ b/contracts/protocol/sources/entry.move
@@ -167,7 +167,7 @@ module fractalmind_protocol::entry {
 
     public entry fun create_governance(
         admin_cap: &OrgAdminCap,
-        org: &Organization,
+        org: &mut Organization,
         ctx: &mut TxContext,
     ) {
         governance::create_governance(admin_cap, org, ctx);

--- a/contracts/protocol/sources/fractal.move
+++ b/contracts/protocol/sources/fractal.move
@@ -82,7 +82,7 @@ module fractalmind_protocol::fractal {
     /// (we require parent admin cap + child admin cap).
     public fun detach_sub_organization(
         parent_admin_cap: &OrgAdminCap,
-        _child_admin_cap: &OrgAdminCap,
+        child_admin_cap: &OrgAdminCap,
         parent_org: &mut Organization,
         child_org: &mut Organization,
     ) {
@@ -96,6 +96,10 @@ module fractalmind_protocol::fractal {
         assert!(
             organization::has_child_org(parent_org, child_id),
             constants::e_org_not_child(),
+        );
+        assert!(
+            organization::admin_cap_org_id(child_admin_cap) == child_id,
+            constants::e_not_admin(),
         );
 
         organization::remove_child_org(parent_org, child_id);

--- a/contracts/protocol/sources/governance.move
+++ b/contracts/protocol/sources/governance.move
@@ -98,7 +98,7 @@ module fractalmind_protocol::governance {
     #[allow(lint(self_transfer))]
     public fun create_governance(
         admin_cap: &OrgAdminCap,
-        org: &Organization,
+        org: &mut Organization,
         ctx: &mut TxContext,
     ) {
         assert!(
@@ -106,6 +106,7 @@ module fractalmind_protocol::governance {
             constants::e_not_admin(),
         );
         assert!(organization::is_active(org), constants::e_org_not_active());
+        assert!(!organization::governance_created(org), constants::e_gov_already_exists());
 
         let governance = Governance {
             id: object::new(ctx),
@@ -119,6 +120,7 @@ module fractalmind_protocol::governance {
             admin: tx_context::sender(ctx),
         });
 
+        organization::mark_governance_created(org);
         transfer::share_object(governance);
     }
 

--- a/contracts/protocol/sources/organization.move
+++ b/contracts/protocol/sources/organization.move
@@ -48,6 +48,8 @@ module fractalmind_protocol::organization {
         child_org_count: u64,
         /// nesting depth (0 = root)
         depth: u64,
+        /// true after a governance object is created for this org
+        governance_created: bool,
         created_at: u64,
     }
 
@@ -129,6 +131,7 @@ module fractalmind_protocol::organization {
             child_orgs: table::new(ctx),
             child_org_count: 0,
             depth: 0,
+            governance_created: false,
             created_at,
         };
         let org_id = object::id(&org);
@@ -254,6 +257,10 @@ module fractalmind_protocol::organization {
         org.parent_org = option::none();
     }
 
+    public(package) fun mark_governance_created(org: &mut Organization) {
+        org.governance_created = true;
+    }
+
     /// Create a sub-organization (called from fractal module).
     #[allow(lint(self_transfer))]
     public(package) fun create_sub_organization(
@@ -288,6 +295,7 @@ module fractalmind_protocol::organization {
             child_orgs: table::new(ctx),
             child_org_count: 0,
             depth,
+            governance_created: false,
             created_at,
         };
         let org_id = object::id(&org);
@@ -326,6 +334,7 @@ module fractalmind_protocol::organization {
     public fun depth(org: &Organization): u64 { org.depth }
     public fun parent_org(org: &Organization): Option<ID> { org.parent_org }
     public fun child_org_count(org: &Organization): u64 { org.child_org_count }
+    public fun governance_created(org: &Organization): bool { org.governance_created }
     public fun has_agent(org: &Organization, agent: address): bool {
         table::contains(&org.agents, agent)
     }

--- a/contracts/protocol/sources/task.move
+++ b/contracts/protocol/sources/task.move
@@ -222,6 +222,7 @@ module fractalmind_protocol::task {
         assert!(task.status == constants::task_status_verified(), constants::e_task_invalid_transition());
 
         let assignee = *option::borrow(&task.assignee);
+        assert!(agent::cert_org_id(assignee_cert) == task.org_id, constants::e_unauthorized());
         assert!(agent::cert_agent(assignee_cert) == assignee, constants::e_unauthorized());
 
         task.status = constants::task_status_completed();

--- a/contracts/protocol/sources/tests/agent_tests.move
+++ b/contracts/protocol/sources/tests/agent_tests.move
@@ -1,5 +1,6 @@
 #[test_only]
 module fractalmind_protocol::agent_tests {
+    use sui::object;
     use sui::test_scenario::{Self as ts};
     use std::string;
     use std::vector;
@@ -169,6 +170,33 @@ module fractalmind_protocol::agent_tests {
             let tags = agent::cert_capability_tags(&cert);
             assert!(vector::length(&tags) == 2, 0);
             ts::return_to_sender(&scenario, cert);
+        };
+
+        ts::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 2001)]
+    fun test_deactivate_agent_with_mismatched_org_fails() {
+        let mut scenario = ts::begin(ADMIN);
+        setup_org(&mut scenario);
+
+        ts::next_tx(&mut scenario, AGENT1);
+        {
+            let mut org = ts::take_shared<Organization>(&scenario);
+            agent::register_agent(&mut org, vector::empty(), ts::ctx(&mut scenario));
+            ts::return_shared(org);
+        };
+
+        ts::next_tx(&mut scenario, AGENT1);
+        {
+            let mut org = ts::take_shared<Organization>(&scenario);
+            let registry = organization::create_test_registry(ts::ctx(&mut scenario));
+            let mut fake_cert = agent::create_test_cert(object::id(&registry), AGENT1, ts::ctx(&mut scenario));
+            organization::destroy_test_registry(registry);
+            agent::deactivate_agent(&mut fake_cert, &mut org, ts::ctx(&mut scenario));
+            ts::return_shared(org);
+            agent::destroy_test_cert(fake_cert);
         };
 
         ts::end(scenario);

--- a/contracts/protocol/sources/tests/fractal_tests.move
+++ b/contracts/protocol/sources/tests/fractal_tests.move
@@ -195,4 +195,77 @@ module fractalmind_protocol::fractal_tests {
 
         ts::end(scenario);
     }
+
+    #[test]
+    #[expected_failure(abort_code = 2002)]
+    fun test_detach_sub_organization_with_wrong_child_cap_fails() {
+        let mut scenario = ts::begin(ADMIN);
+
+        // Create root org
+        ts::next_tx(&mut scenario, ADMIN);
+        {
+            let mut registry = organization::create_test_registry(ts::ctx(&mut scenario));
+            organization::create_organization(
+                &mut registry,
+                string::utf8(b"DetachWrongCapRoot"),
+                string::utf8(b"root for wrong child cap test"),
+                ts::ctx(&mut scenario),
+            );
+            organization::destroy_test_registry(registry);
+        };
+
+        // Create sub-org
+        ts::next_tx(&mut scenario, ADMIN);
+        {
+            let admin_cap = ts::take_from_sender<OrgAdminCap>(&scenario);
+            let mut parent = ts::take_shared<Organization>(&scenario);
+            let mut registry = organization::create_test_registry(ts::ctx(&mut scenario));
+
+            fractal::create_sub_organization(
+                &admin_cap,
+                &mut registry,
+                &mut parent,
+                string::utf8(b"DetachWrongCapChild"),
+                string::utf8(b"child"),
+                ts::ctx(&mut scenario),
+            );
+
+            organization::destroy_test_registry(registry);
+            ts::return_shared(parent);
+            ts::return_to_sender(&scenario, admin_cap);
+        };
+
+        // Try detach with parent cap passed as both parent and child cap.
+        ts::next_tx(&mut scenario, ADMIN);
+        {
+            let cap_ids = ts::ids_for_sender<OrgAdminCap>(&scenario);
+            let cap_a = ts::take_from_sender_by_id<OrgAdminCap>(
+                &scenario,
+                *std::vector::borrow(&cap_ids, 0),
+            );
+            let cap_b = ts::take_from_sender_by_id<OrgAdminCap>(
+                &scenario,
+                *std::vector::borrow(&cap_ids, 1),
+            );
+
+            let mut org_a = ts::take_shared<Organization>(&scenario);
+            let mut org_b = ts::take_shared<Organization>(&scenario);
+
+            let org_a_is_parent = organization::child_org_count(&org_a) > 0;
+            if (org_a_is_parent) {
+                let parent_cap = if (organization::admin_cap_org_id(&cap_a) == organization::org_id(&org_a)) { &cap_a } else { &cap_b };
+                fractal::detach_sub_organization(parent_cap, parent_cap, &mut org_a, &mut org_b);
+            } else {
+                let parent_cap = if (organization::admin_cap_org_id(&cap_a) == organization::org_id(&org_b)) { &cap_a } else { &cap_b };
+                fractal::detach_sub_organization(parent_cap, parent_cap, &mut org_b, &mut org_a);
+            };
+
+            ts::return_shared(org_b);
+            ts::return_shared(org_a);
+            ts::return_to_sender(&scenario, cap_b);
+            ts::return_to_sender(&scenario, cap_a);
+        };
+
+        ts::end(scenario);
+    }
 }

--- a/contracts/protocol/sources/tests/governance_tests.move
+++ b/contracts/protocol/sources/tests/governance_tests.move
@@ -47,8 +47,8 @@ module fractalmind_protocol::governance_tests {
         ts::next_tx(scenario, ADMIN);
         {
             let admin_cap = ts::take_from_sender<OrgAdminCap>(scenario);
-            let org = ts::take_shared<Organization>(scenario);
-            governance::create_governance(&admin_cap, &org, ts::ctx(scenario));
+            let mut org = ts::take_shared<Organization>(scenario);
+            governance::create_governance(&admin_cap, &mut org, ts::ctx(scenario));
             ts::return_shared(org);
             ts::return_to_sender(scenario, admin_cap);
         };
@@ -98,6 +98,25 @@ module fractalmind_protocol::governance_tests {
             assert!(governance::proposal_status(&proposal) == constants::proposal_status_voting(), 1);
             ts::return_shared(proposal);
             ts::return_shared(governance_obj);
+        };
+
+        ts::end(scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 6007)]
+    fun test_duplicate_governance_creation_fails() {
+        let mut scenario = ts::begin(ADMIN);
+        setup_org_and_agents(&mut scenario);
+
+        ts::next_tx(&mut scenario, ADMIN);
+        {
+            let admin_cap = ts::take_from_sender<OrgAdminCap>(&scenario);
+            let mut org = ts::take_shared<Organization>(&scenario);
+            governance::create_governance(&admin_cap, &mut org, ts::ctx(&mut scenario));
+            governance::create_governance(&admin_cap, &mut org, ts::ctx(&mut scenario));
+            ts::return_shared(org);
+            ts::return_to_sender(&scenario, admin_cap);
         };
 
         ts::end(scenario);

--- a/contracts/protocol/sources/tests/task_tests.move
+++ b/contracts/protocol/sources/tests/task_tests.move
@@ -281,6 +281,73 @@ module fractalmind_protocol::task_tests {
     }
 
     #[test]
+    #[expected_failure(abort_code = 2001)]
+    fun test_complete_task_with_org_mismatched_assignee_cert_fails() {
+        let mut scenario = ts::begin(ADMIN);
+        setup_org_and_agent(&mut scenario);
+
+        // Create task
+        ts::next_tx(&mut scenario, AGENT1);
+        {
+            let cert = ts::take_from_sender<AgentCertificate>(&scenario);
+            let mut org = ts::take_shared<Organization>(&scenario);
+            task::create_task(
+                &mut org,
+                &cert,
+                string::utf8(b"Complete wrong cert"),
+                string::utf8(b"org mismatch should fail"),
+                ts::ctx(&mut scenario),
+            );
+            ts::return_shared(org);
+            ts::return_to_sender(&scenario, cert);
+        };
+
+        // Assign
+        ts::next_tx(&mut scenario, AGENT1);
+        {
+            let cert = ts::take_from_sender<AgentCertificate>(&scenario);
+            let org = ts::take_shared<Organization>(&scenario);
+            let mut task_obj = ts::take_shared<Task>(&scenario);
+            task::assign_task(&mut task_obj, &org, &cert, ts::ctx(&mut scenario));
+            ts::return_shared(task_obj);
+            ts::return_shared(org);
+            ts::return_to_sender(&scenario, cert);
+        };
+
+        // Submit
+        ts::next_tx(&mut scenario, AGENT1);
+        {
+            let mut task_obj = ts::take_shared<Task>(&scenario);
+            task::submit_task(&mut task_obj, string::utf8(b"work"), ts::ctx(&mut scenario));
+            ts::return_shared(task_obj);
+        };
+
+        // Verify
+        ts::next_tx(&mut scenario, ADMIN);
+        {
+            let admin_cap = ts::take_from_sender<OrgAdminCap>(&scenario);
+            let mut task_obj = ts::take_shared<Task>(&scenario);
+            task::verify_task(&admin_cap, &mut task_obj, ts::ctx(&mut scenario));
+            ts::return_shared(task_obj);
+            ts::return_to_sender(&scenario, admin_cap);
+        };
+
+        // Complete with forged cert that has correct assignee address but wrong org id.
+        ts::next_tx(&mut scenario, ADMIN);
+        {
+            let admin_cap = ts::take_from_sender<OrgAdminCap>(&scenario);
+            let mut task_obj = ts::take_shared<Task>(&scenario);
+            let mut fake_cert = agent::create_test_cert(object::id(&task_obj), AGENT1, ts::ctx(&mut scenario));
+            task::complete_task(&admin_cap, &mut task_obj, &mut fake_cert, ts::ctx(&mut scenario));
+            ts::return_shared(task_obj);
+            ts::return_to_sender(&scenario, admin_cap);
+            agent::destroy_test_cert(fake_cert);
+        };
+
+        ts::end(scenario);
+    }
+
+    #[test]
     #[expected_failure(abort_code = 5001)]
     fun test_submit_before_assign_fails() {
         let mut scenario = ts::begin(ADMIN);


### PR DESCRIPTION
## Summary
- enforce cert/org consistency in deactivate_agent and complete_task
- enforce child admin cap ownership in detach_sub_organization
- enforce a single governance object per organization
- add regression tests for all four security issues

## Security Fixes
- **Authorization hardening**
  - ensure AgentCertificate.org_id matches target org in deactivate_agent
  - ensure assignee cert org matches task org in complete_task
  - ensure child admin cap matches child org in detach_sub_organization
- **Governance invariant**
  - add E_GOV_ALREADY_EXISTS and org-level governance_created guard
  - update governance creation entrypoint to mutate org state safely

## Tests
- Added regression tests:
  - 	est_deactivate_agent_with_mismatched_org_fails
  - 	est_complete_task_with_org_mismatched_assignee_cert_fails
  - 	est_detach_sub_organization_with_wrong_child_cap_fails
  - 	est_duplicate_governance_creation_fails
- Validation:
  - 
px tsx --test tests/sdk.test.ts (23/23 pass)
  - sui move test (48/48 pass)

## Notes
- This branch was pushed from fork cafeTechne/fractalmind-protocol due lack of direct push permission to upstream.