### PR TITLE
feat: add rename_organization function

### DIFF
--- a/.github/workflows/deploy-contracts.yml
+++ b/.github/workflows/deploy-contracts.yml
@@ -11,6 +11,18 @@ on:
           - testnet
           - mainnet
         default: testnet
+      action:
+        description: 'Deploy action'
+        required: true
+        type: choice
+        options:
+          - publish
+          - upgrade
+        default: publish
+      upgrade_cap:
+        description: 'UpgradeCap object ID (required for upgrade)'
+        required: false
+        default: ''
       ref:
         description: 'Branch, tag, or commit to deploy'
         required: false
@@ -160,12 +172,26 @@ jobs:
           cd contracts/protocol
 
           GAS_BUDGET=500000000
-          echo "Publishing fractalmind_protocol with gas budget $GAS_BUDGET"
+          ACTION="${{ inputs.action }}"
+          UPGRADE_CAP="${{ inputs.upgrade_cap }}"
 
-          set +e
-          DEPLOY_OUTPUT=$(sui client publish --gas-budget "$GAS_BUDGET" --silence-warnings --json 2>&1)
-          EXIT_CODE=$?
-          set -e
+          if [ "$ACTION" = "upgrade" ]; then
+            if [ -z "$UPGRADE_CAP" ]; then
+              echo "::error::UpgradeCap object ID is required for upgrade"
+              exit 1
+            fi
+            echo "Upgrading fractalmind_protocol with UpgradeCap $UPGRADE_CAP"
+            set +e
+            DEPLOY_OUTPUT=$(sui client upgrade --gas-budget "$GAS_BUDGET" --upgrade-capability "$UPGRADE_CAP" --silence-warnings --json 2>&1)
+            EXIT_CODE=$?
+            set -e
+          else
+            echo "Publishing fractalmind_protocol with gas budget $GAS_BUDGET"
+            set +e
+            DEPLOY_OUTPUT=$(sui client publish --gas-budget "$GAS_BUDGET" --silence-warnings --json 2>&1)
+            EXIT_CODE=$?
+            set -e
+          fi
 
           echo "$DEPLOY_OUTPUT" > deploy_output.json
           echo "=== Publish output ==="

--- a/.github/workflows/rename-org.yml
+++ b/.github/workflows/rename-org.yml
@@ -1,0 +1,77 @@
+name: Rename Organization
+
+on:
+  workflow_dispatch:
+    inputs:
+      org_id:
+        description: 'Organization object ID'
+        required: true
+      admin_cap_id:
+        description: 'OrgAdminCap object ID'
+        required: true
+      new_name:
+        description: 'New organization name'
+        required: true
+
+jobs:
+  rename:
+    name: Rename org on Testnet
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Sui CLI
+        run: |
+          set -euo pipefail
+          SUI_VERSION="testnet-v1.67.1"
+          ARCHIVE="sui-${SUI_VERSION}-ubuntu-x86_64.tgz"
+          curl -fsSL "https://github.com/MystenLabs/sui/releases/download/${SUI_VERSION}/${ARCHIVE}" -o sui.tgz
+          tar -xzf sui.tgz
+          FOUND=$(find . -type f -name sui -perm -111 | head -1)
+          if [ -n "$FOUND" ]; then sudo mv "$FOUND" /usr/local/bin/sui; else sudo mv sui /usr/local/bin/; fi
+          rm -rf sui.tgz target/
+          sui --version
+
+      - name: Configure client
+        run: |
+          set -euo pipefail
+          rm -rf "$HOME/.sui"
+          sui client --yes new-env --alias testnet --rpc "https://fullnode.testnet.sui.io:443" || true
+          sui client switch --env testnet
+
+      - name: Import wallet
+        env:
+          SUI_MNEMONICS: ${{ secrets.TESTNET_SUI_MNEMONICS }}
+        run: |
+          set -euo pipefail
+          DERIVATION_PATH="m/44'/784'/0'/0'/0'"
+          rm -f "$HOME/.sui/sui_config/sui.keystore"
+          sui keytool import "$SUI_MNEMONICS" ed25519 "$DERIVATION_PATH"
+          WALLET_ADDRESS=$(sui keytool list | grep -o "0x[0-9a-fA-F]\{64\}" | head -1)
+          sui client switch --address "$WALLET_ADDRESS"
+          echo "Wallet: $WALLET_ADDRESS"
+
+      - name: Rename organization
+        run: |
+          set -euo pipefail
+          PACKAGE_ID="0x685d6fb6ed8b0e679bb467ea73111819ec6ff68b1466d24ca26b400095dcdf24"
+          REGISTRY_ID="0xfb8611bf2eb94b950e4ad47a76adeaab8ddda23e602c77e7464cc20572a547e3"
+
+          echo "Renaming org ${{ inputs.org_id }} to '${{ inputs.new_name }}'"
+
+          sui client call \
+            --package "$PACKAGE_ID" \
+            --module entry \
+            --function rename_organization \
+            --args \
+              "${{ inputs.admin_cap_id }}" \
+              "$REGISTRY_ID" \
+              "${{ inputs.org_id }}" \
+              "${{ inputs.new_name }}" \
+            --gas-budget 50000000 \
+            --json
+
+          echo "Done! Organization renamed."
+
+      - name: Cleanup
+        if: always()
+        run: rm -f "$HOME/.sui/sui_config/sui.keystore"

--- a/contracts/protocol/Move.toml
+++ b/contracts/protocol/Move.toml
@@ -2,6 +2,7 @@
 name = "fractalmind_protocol"
 version = "0.0.1"
 edition = "2024.beta"
+published-at = "0x685d6fb6ed8b0e679bb467ea73111819ec6ff68b1466d24ca26b400095dcdf24"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
@@ -9,4 +10,7 @@ subdir = "crates/sui-framework/packages/sui-framework"
 rev = "framework/testnet"
 
 [addresses]
-fractalmind_protocol = "0x0"
+fractalmind_protocol = "0x685d6fb6ed8b0e679bb467ea73111819ec6ff68b1466d24ca26b400095dcdf24"
+
+[environments]
+testnet = "4c78adac"

--- a/contracts/protocol/sources/entry.move
+++ b/contracts/protocol/sources/entry.move
@@ -50,6 +50,15 @@ module fractalmind_protocol::entry {
         organization::transfer_admin(admin_cap, org, new_admin, ctx);
     }
 
+    public entry fun rename_organization(
+        admin_cap: &OrgAdminCap,
+        registry: &mut ProtocolRegistry,
+        org: &mut Organization,
+        new_name: String,
+    ) {
+        organization::rename_organization(admin_cap, registry, org, new_name);
+    }
+
     // ===== Agent Entry Points =====
 
     public entry fun register_agent(

--- a/contracts/protocol/sources/organization.move
+++ b/contracts/protocol/sources/organization.move
@@ -83,6 +83,12 @@ module fractalmind_protocol::organization {
         new_admin: address,
     }
 
+    public struct OrgRenamed has copy, drop {
+        org_id: ID,
+        old_name: String,
+        new_name: String,
+    }
+
     // ===== Init (called from bootstrap) =====
 
     /// Create and share the global ProtocolRegistry. Called once at publish.
@@ -187,6 +193,37 @@ module fractalmind_protocol::organization {
         event::emit(OrgDescriptionUpdated {
             org_id: object::id(org),
             new_description,
+        });
+    }
+
+    /// Admin-only: rename an organization. Updates both org and name_registry.
+    public fun rename_organization(
+        admin_cap: &OrgAdminCap,
+        registry: &mut ProtocolRegistry,
+        org: &mut Organization,
+        new_name: String,
+    ) {
+        assert!(admin_cap.org_id == object::id(org), constants::e_not_admin());
+        assert!(org.is_active, constants::e_org_not_active());
+        assert!(std::string::length(&new_name) > 0, constants::e_empty_name());
+        assert!(
+            !table::contains(&registry.name_registry, new_name),
+            constants::e_org_name_taken(),
+        );
+
+        let old_name = org.name;
+
+        // Update name_registry: remove old, add new
+        table::remove(&mut registry.name_registry, old_name);
+        table::add(&mut registry.name_registry, new_name, object::id(org));
+
+        // Update org name
+        org.name = new_name;
+
+        event::emit(OrgRenamed {
+            org_id: object::id(org),
+            old_name,
+            new_name,
         });
     }
 


### PR DESCRIPTION
## Summary
- Add `rename_organization()` function to the Move contract (admin-only)
- Updates both `Organization.name` and `ProtocolRegistry.name_registry` atomically
- Enforces name uniqueness and non-empty name
- Add `OrgRenamed` event for tracking
- Update deploy workflow to support `upgrade` action (with UpgradeCap)
- Add `rename-org.yml` workflow for renaming orgs via GitHub Actions

## Context
Testnet has 3 "SuLabs" organizations from different iterations. Need to rename the two inactive ones to "Test1" and "Test2" so the active one (3 agents) is clearly distinguishable.

## After merge — execution steps
1. Trigger deploy workflow: action=upgrade, upgrade_cap=`0xbcbed274939e0eeef13969b013bc18efc7f3476c7f2fea5ea2ed31cabfdfed9f`
2. Trigger rename-org workflow twice:
   - org=`0x9f6e36a1e0fe240b429ac1278f8b76d2d3ef13efd0f8f4863f9cf33d967b157f`, cap=`0x3a0a8615a057ebba2c76050de0d11437cccc99d8922718d37cb954bed08bf098`, name="Test1"
   - org=`0x2f8f899df37aab663cf8d3fda1322a78e3f4b9decd12fb222bb6fc7fef412ad4`, cap=`0x94ab4e5678327b54f3ea31796d4ec85736938aaffd38059be501c45bb41cb053`, name="Test2"

## Test plan
- [x] `sui move build` passes
- [x] `sui move test` — 44/44 tests pass
- [ ] Deploy upgrade to Testnet
- [ ] Rename two orgs via workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)