### PR TITLE
fix: revert incompatible changes for contract upgrade

### DIFF
--- a/contracts/protocol/sources/entry.move
+++ b/contracts/protocol/sources/entry.move
@@ -176,7 +176,7 @@ module fractalmind_protocol::entry {
 
     public entry fun create_governance(
         admin_cap: &OrgAdminCap,
-        org: &mut Organization,
+        org: &Organization,
         ctx: &mut TxContext,
     ) {
         governance::create_governance(admin_cap, org, ctx);

--- a/contracts/protocol/sources/governance.move
+++ b/contracts/protocol/sources/governance.move
@@ -98,7 +98,7 @@ module fractalmind_protocol::governance {
     #[allow(lint(self_transfer))]
     public fun create_governance(
         admin_cap: &OrgAdminCap,
-        org: &mut Organization,
+        org: &Organization,
         ctx: &mut TxContext,
     ) {
         assert!(
@@ -106,7 +106,6 @@ module fractalmind_protocol::governance {
             constants::e_not_admin(),
         );
         assert!(organization::is_active(org), constants::e_org_not_active());
-        assert!(!organization::governance_created(org), constants::e_gov_already_exists());
 
         let governance = Governance {
             id: object::new(ctx),
@@ -120,7 +119,6 @@ module fractalmind_protocol::governance {
             admin: tx_context::sender(ctx),
         });
 
-        organization::mark_governance_created(org);
         transfer::share_object(governance);
     }
 

--- a/contracts/protocol/sources/organization.move
+++ b/contracts/protocol/sources/organization.move
@@ -48,8 +48,6 @@ module fractalmind_protocol::organization {
         child_org_count: u64,
         /// nesting depth (0 = root)
         depth: u64,
-        /// true after a governance object is created for this org
-        governance_created: bool,
         created_at: u64,
     }
 
@@ -137,7 +135,6 @@ module fractalmind_protocol::organization {
             child_orgs: table::new(ctx),
             child_org_count: 0,
             depth: 0,
-            governance_created: false,
             created_at,
         };
         let org_id = object::id(&org);
@@ -294,10 +291,6 @@ module fractalmind_protocol::organization {
         org.parent_org = option::none();
     }
 
-    public(package) fun mark_governance_created(org: &mut Organization) {
-        org.governance_created = true;
-    }
-
     /// Create a sub-organization (called from fractal module).
     #[allow(lint(self_transfer))]
     public(package) fun create_sub_organization(
@@ -332,7 +325,6 @@ module fractalmind_protocol::organization {
             child_orgs: table::new(ctx),
             child_org_count: 0,
             depth,
-            governance_created: false,
             created_at,
         };
         let org_id = object::id(&org);
@@ -371,7 +363,6 @@ module fractalmind_protocol::organization {
     public fun depth(org: &Organization): u64 { org.depth }
     public fun parent_org(org: &Organization): Option<ID> { org.parent_org }
     public fun child_org_count(org: &Organization): u64 { org.child_org_count }
-    public fun governance_created(org: &Organization): bool { org.governance_created }
     public fun has_agent(org: &Organization, agent: address): bool {
         table::contains(&org.agents, agent)
     }

--- a/contracts/protocol/sources/tests/governance_tests.move
+++ b/contracts/protocol/sources/tests/governance_tests.move
@@ -47,8 +47,8 @@ module fractalmind_protocol::governance_tests {
         ts::next_tx(scenario, ADMIN);
         {
             let admin_cap = ts::take_from_sender<OrgAdminCap>(scenario);
-            let mut org = ts::take_shared<Organization>(scenario);
-            governance::create_governance(&admin_cap, &mut org, ts::ctx(scenario));
+            let org = ts::take_shared<Organization>(scenario);
+            governance::create_governance(&admin_cap, &org, ts::ctx(scenario));
             ts::return_shared(org);
             ts::return_to_sender(scenario, admin_cap);
         };
@@ -98,25 +98,6 @@ module fractalmind_protocol::governance_tests {
             assert!(governance::proposal_status(&proposal) == constants::proposal_status_voting(), 1);
             ts::return_shared(proposal);
             ts::return_shared(governance_obj);
-        };
-
-        ts::end(scenario);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = 6007)]
-    fun test_duplicate_governance_creation_fails() {
-        let mut scenario = ts::begin(ADMIN);
-        setup_org_and_agents(&mut scenario);
-
-        ts::next_tx(&mut scenario, ADMIN);
-        {
-            let admin_cap = ts::take_from_sender<OrgAdminCap>(&scenario);
-            let mut org = ts::take_shared<Organization>(&scenario);
-            governance::create_governance(&admin_cap, &mut org, ts::ctx(&mut scenario));
-            governance::create_governance(&admin_cap, &mut org, ts::ctx(&mut scenario));
-            ts::return_shared(org);
-            ts::return_to_sender(&scenario, admin_cap);
         };
 
         ts::end(scenario);


### PR DESCRIPTION
## Summary
- Revert `governance_created` field addition to Organization struct (14→15 fields broke compatible upgrade)
- Revert `create_governance` signature from `&mut Organization` to `&Organization`
- Remove `test_duplicate_governance_creation_fails` test (depended on removed check)
- Keep `rename_organization` function and all other additive (compatible) changes

## Context
The upgrade to Testnet failed because commit cf041ad introduced struct field and function signature changes that violate SUI's "compatible" upgrade policy. This PR reverts only the incompatible parts.

## Test plan
- [x] `sui move build` passes
- [x] All 47 tests pass
- [ ] Trigger upgrade workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)