### PR TITLE
O4: enable remote SDK prepublish validation workflow

### DIFF
--- a/.github/workflows/sdk-prepublish-validate.yml
+++ b/.github/workflows/sdk-prepublish-validate.yml
@@ -1,0 +1,118 @@
+name: SDK Pre-publish Validation
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-sdk-prepublish:
+    name: Validate npm pre-publish chain (no publish)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+          cache-dependency-path: sdk/package-lock.json
+
+      - name: Resolve npm auth token
+        id: npm-token
+        env:
+          RAW_NPMJS_ACCESS_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -n "${RAW_NPMJS_ACCESS_TOKEN:-}" ]; then
+            echo "token_source=NPMJS_ACCESS_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "NODE_AUTH_TOKEN=${RAW_NPMJS_ACCESS_TOKEN}" >> "$GITHUB_ENV"
+          else
+            echo "::error::Missing npm auth secret. Set secrets.NPMJS_ACCESS_TOKEN."
+            exit 1
+          fi
+
+      - name: Verify npm authentication
+        id: npm-auth
+        env:
+          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          NPM_USERNAME="$(npm whoami)"
+          if [ -z "${NPM_USERNAME}" ]; then
+            echo "::error::npm whoami returned empty username."
+            exit 1
+          fi
+          echo "npm_username=${NPM_USERNAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify @fractalmind-ai organization membership
+        id: npm-org
+        env:
+          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
+          NPM_USERNAME: ${{ steps.npm-auth.outputs.npm_username }}
+        run: |
+          set -euo pipefail
+          npm org ls fractalmind-ai "$NPM_USERNAME" --json > org-membership.json
+          ORG_ROLE="$(jq -r --arg u "$NPM_USERNAME" '.[$u] // empty' org-membership.json)"
+          if [ -z "${ORG_ROLE}" ] || [ "${ORG_ROLE}" = "null" ]; then
+            echo "::error::Unable to verify npm org membership for ${NPM_USERNAME} in @fractalmind-ai."
+            cat org-membership.json
+            exit 1
+          fi
+          echo "org_role=${ORG_ROLE}" >> "$GITHUB_OUTPUT"
+
+      - name: Optional scope package visibility probe
+        id: scope-probe
+        continue-on-error: true
+        env:
+          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
+        run: npm access list packages @fractalmind-ai --json > scope-packages.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Pack
+        run: npm pack --json | tee pack-result.json
+
+      - name: Pre-publish dry run
+        env:
+          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
+        run: npm publish --dry-run --access public
+
+      - name: Upload prepublish artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-prepublish-validation-${{ github.run_id }}
+          path: |
+            sdk/pack-result.json
+            sdk/*.tgz
+
+      - name: Summary
+        run: |
+          cat <<EOF >> "$GITHUB_STEP_SUMMARY"
+          # SDK Pre-publish Validation (No Real Publish)
+
+          This workflow only validates the npm pre-publish chain.
+          - Trigger mode: \`workflow_dispatch\`
+          - Token source: \`${{ steps.npm-token.outputs.token_source }}\`
+          - npm user: \`${{ steps.npm-auth.outputs.npm_username }}\`
+          - @fractalmind-ai role: \`${{ steps.npm-org.outputs.org_role }}\`
+          - Optional scope probe: \`${{ steps.scope-probe.outcome }}\` (non-blocking; may fail under limited npm role)
+          - Commands: \`npm ci\`, \`npm run build\`, \`npm test\`, \`npm pack\`, \`npm publish --dry-run --access public\`
+          - \`npm whoami\` + org membership check are hard gates to avoid dry-run false positives.
+          - No real publish is executed in this workflow.
+          EOF

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 contracts/protocol/build/
 contracts/protocol/Move.lock
+sdk/*.tgz
 
 # IDE
 .idea/

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -22,7 +22,7 @@ npm install
 ## Quick Start
 
 ```ts
-import { FractalMindSDK } from '@fractalmind/protocol-sdk';
+import { FractalMindSDK } from '@fractalmind-ai/fractalmind-sdk';
 
 const sdk = new FractalMindSDK({
   packageId: '0xYOUR_PACKAGE_ID',

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@fractalmind/protocol-sdk",
+  "name": "@fractalmind-ai/fractalmind-sdk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@fractalmind/protocol-sdk",
+      "name": "@fractalmind-ai/fractalmind-sdk",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -775,6 +775,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.1.tgz",
       "integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -820,6 +821,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,14 +1,25 @@
 {
-  "name": "@fractalmind/protocol-sdk",
+  "name": "@fractalmind-ai/fractalmind-sdk",
   "version": "0.1.0",
   "description": "TypeScript SDK for FractalMind Protocol on Sui",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist",
-    "src"
+    "README.md"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Purpose
Enable O4 pre-publish validation to run on GitHub Actions remotely (no real publish).

## Scope (minimal)
- add `.github/workflows/sdk-prepublish-validate.yml`
- align SDK package/readme/lock name to `@fractalmind-ai/fractalmind-sdk`
- ignore local `sdk/*.tgz` artifacts

## Notes
- no production publish performed
- workflow uses `NPMJS_ACCESS_TOKEN`
- npm 11 probe command uses `npm access list packages`
