### PR TITLE
O4: add SDK publish workflow (formal npm publish)

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -1,0 +1,108 @@
+name: SDK Publish
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-sdk:
+    name: Publish SDK to npm
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+          cache-dependency-path: sdk/package-lock.json
+
+      - name: Resolve npm auth token
+        id: npm-token
+        env:
+          RAW_NPMJS_ACCESS_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -n "${RAW_NPMJS_ACCESS_TOKEN:-}" ]; then
+            echo "token_source=NPMJS_ACCESS_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "NODE_AUTH_TOKEN=${RAW_NPMJS_ACCESS_TOKEN}" >> "$GITHUB_ENV"
+          else
+            echo "::error::Missing npm auth secret. Set secrets.NPMJS_ACCESS_TOKEN."
+            exit 1
+          fi
+
+      - name: Verify npm authentication
+        id: npm-auth
+        env:
+          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          NPM_USERNAME="$(npm whoami)"
+          if [ -z "${NPM_USERNAME}" ]; then
+            echo "::error::npm whoami returned empty username."
+            exit 1
+          fi
+          echo "npm_username=${NPM_USERNAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify @fractalmind-ai organization membership
+        id: npm-org
+        env:
+          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
+          NPM_USERNAME: ${{ steps.npm-auth.outputs.npm_username }}
+        run: |
+          set -euo pipefail
+          npm org ls fractalmind-ai "$NPM_USERNAME" --json > org-membership.json
+          ORG_ROLE="$(jq -r --arg u "$NPM_USERNAME" '.[$u] // empty' org-membership.json)"
+          if [ -z "${ORG_ROLE}" ] || [ "${ORG_ROLE}" = "null" ]; then
+            echo "::error::Unable to verify npm org membership for ${NPM_USERNAME} in @fractalmind-ai."
+            cat org-membership.json
+            exit 1
+          fi
+          echo "org_role=${ORG_ROLE}" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Pack
+        run: npm pack --json | tee pack-result.json
+
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN }}
+        run: npm publish --access public
+
+      - name: Upload publish artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-publish-${{ github.run_id }}
+          path: |
+            sdk/pack-result.json
+            sdk/*.tgz
+
+      - name: Summary
+        run: |
+          cat <<EOF_SUMMARY >> "$GITHUB_STEP_SUMMARY"
+          # SDK Publish
+
+          Publish completed.
+          - Trigger mode: `workflow_dispatch`
+          - Token source: `${{ steps.npm-token.outputs.token_source }}`
+          - npm user: `${{ steps.npm-auth.outputs.npm_username }}`
+          - @fractalmind-ai role: `${{ steps.npm-org.outputs.org_role }}`
+          - Commands: `npm ci`, `npm run build`, `npm test`, `npm pack`, `npm publish --access public`
+          EOF_SUMMARY


### PR DESCRIPTION
## Purpose
Add the formal SDK publish workflow for O4 so it can be reviewed and merged with minimal scope.

## Scope
- Add `.github/workflows/sdk-publish.yml` only.

## Behavior
- Reuses GitHub Actions secret: `NPMJS_ACCESS_TOKEN`
- Performs npm auth and org membership checks
- Runs build/test/pack, then executes formal publish:
  - `npm publish --access public`

## Notes
- This PR only introduces the workflow file.
- No publish run is triggered in this PR.
